### PR TITLE
boss now fires when respawned

### DIFF
--- a/src/bossinputTEST.js
+++ b/src/bossinputTEST.js
@@ -20,6 +20,9 @@ export default class BossInputHandler{
       }
     });
   }
+  updateBoss(boss) {
+    this.boss = boss;
+  }
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ b.setDirection();
 b.meleeAttack();
 
 new InputHandler(player);
-new BossInputHandler(boss);
+var bossInput = new BossInputHandler(boss);
 
 let lastTime = 0;
 class Game {
@@ -177,6 +177,7 @@ class Game {
 
   nextLevel() {
     boss = new Boss(10,player,GAME_WIDTH, GAME_HEIGHT,a);
+    bossInput.updateBoss(boss);
     player.resetPlayer();
   }
 


### PR DESCRIPTION
boss input was broken and boss would not fire when P was pressed after respawning; boss now fires properly after

functionality for resetting all inputs should be added now so everything works right after respawn